### PR TITLE
Change Github Actions to single run

### DIFF
--- a/.github/workflows/stripe-subscriptions.yml
+++ b/.github/workflows/stripe-subscriptions.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [ubuntu-latest]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Parallel runs not working due to how tests are implemented using Stripe API.